### PR TITLE
fix pip install (don't import package at install)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 
 from setuptools import find_packages
 from setuptools import setup
+import re
 
-version = __import__('threddsclient').__version__
+version = re.search(r'__version__ = (.+)\n', open('threddsclient/__init__.py').read()).group(1)
 long_description = (
     open('README.rst').read() + '\n' + open('AUTHORS.rst').read() + '\n' + open('CHANGES.rst').read()
 )

--- a/threddsclient/__init__.py
+++ b/threddsclient/__init__.py
@@ -1,4 +1,3 @@
-import requests
 from .client import download_urls, opendap_urls, read_url, read_xml, crawl
 
 __version__ = '0.3.5'


### PR DESCRIPTION
The problem was that the requirements were not installed when running pip install. And we got the error `ModuleNotFoundError: No module named 'requests'`