### PR TITLE
Adapations to make it work with HYRAX implementation of THREDDS Catalogs

### DIFF
--- a/threddsclient/catalog.py
+++ b/threddsclient/catalog.py
@@ -62,10 +62,18 @@ def find_datasets(soup, catalog):
         if any([x.match(name) for x in catalog.skip]):
             logger.info("Skipping dataset based on 'skips'.  Name: {0}".format(name))
             continue
-        elif ds.get('urlPath') is None:
-            datasets.append(CollectionDataset(ds, catalog))
-        else:
+        elif ds.get('urlPath'):
+            """
+            THREDDS has no urlPath for collections
+            """
             datasets.append(DirectDataset(ds, catalog))
+        elif ds.find_all('access', recursive=False):
+            """
+            HYRAX has data access within sub elements
+            """
+            datasets.append(DirectDataset(ds, catalog))
+        else:
+            datasets.append(CollectionDataset(ds, catalog))
     return datasets
 
 

--- a/threddsclient/client.py
+++ b/threddsclient/client.py
@@ -1,6 +1,4 @@
 import requests
-import sys # while testing
-
 
 def download_urls(url, skip=None, **kwargs):
     """

--- a/threddsclient/client.py
+++ b/threddsclient/client.py
@@ -1,4 +1,5 @@
 import requests
+import sys # while testing
 
 
 def download_urls(url, skip=None, **kwargs):

--- a/threddsclient/client.py
+++ b/threddsclient/client.py
@@ -1,5 +1,6 @@
 import requests
 
+
 def download_urls(url, skip=None, **kwargs):
     """
     Returns a list of file download urls listed in the catalog at `url`

--- a/threddsclient/nodes.py
+++ b/threddsclient/nodes.py
@@ -10,8 +10,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 FILE_SERVICE = ["HTTPServer"]
-OPENDAP_SERVICE = ["OPENDAP", "OpenDAP"]
-WMS_SERVICE = ["WMS"]
+OPENDAP_SERVICE = ["OPENDAP", "OpenDAP", "OPeNDAP"]
+WMS_SERVICE = ["WMS", "wms"]
 WCS_SERVICE = ["WCS"]
 
 
@@ -39,6 +39,9 @@ class Service(Node):
         Node.__init__(self, soup, catalog)
         self.base = soup.get('base')
         self.url = urlparse.urljoin(self.catalog.url, self.base)
+        # To fix issues with HYRAX servers
+        if not self.url.endswith('/'):
+            self.url = self.url + '/'
         self.service_type = soup.get('serviceType')
         self.content_type = "application/service"
         self.services = [Service(s, self.catalog) for s in soup.find_all('service', recursive=False)]
@@ -100,6 +103,8 @@ class Dataset(Node):
         elif self.soup.metadata:
             if self.soup.metadata.serviceName:
                 service_name = self.soup.metadata.serviceName.text
+        elif self.soup.access:
+            service_name = self.soup.access.get('serviceName')
         elif self.soup.parent.metadata:
             if self.soup.parent.metadata.serviceName:
                 service_name = self.soup.parent.metadata.serviceName.text
@@ -162,7 +167,12 @@ class DirectDataset(Dataset):
     """
     def __init__(self, soup, catalog):
         Dataset.__init__(self, soup, catalog)
-        self.url_path = soup.get('urlPath')
+        if soup.get('urlPath'):
+            # Handling THREDDS
+            self.url_path = soup.get('urlPath')
+        elif soup.access.get('urlPath'):
+            # Handling HYRAX
+            self.url_path = soup.access.get('urlPath')
         self.content_type = "application/netcdf"
         self.modified = self._modified(soup)
         self.bytes = self._bytes(soup)
@@ -171,7 +181,7 @@ class DirectDataset(Dataset):
         url = None
         for service in self.catalog.get_services(self.service_name):
             if service.service_type in service_type:
-                url = urlparse.urljoin(service.url, self.url_path)
+                url = urlparse.urljoin(service.url, self.url_path.removeprefix('/'))
                 break
         return url
 

--- a/threddsclient/nodes.py
+++ b/threddsclient/nodes.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 FILE_SERVICE = ["HTTPServer"]
 OPENDAP_SERVICE = ["OPENDAP", "OpenDAP", "OPeNDAP"]
-WMS_SERVICE = ["WMS", "wms"]
+WMS_SERVICE = ["WMS"]
 WCS_SERVICE = ["WCS"]
 
 

--- a/threddsclient/nodes.py
+++ b/threddsclient/nodes.py
@@ -181,7 +181,7 @@ class DirectDataset(Dataset):
         url = None
         for service in self.catalog.get_services(self.service_name):
             if service.service_type in service_type:
-                url = urlparse.urljoin(service.url, self.url_path.removeprefix('/'))
+                url = urlparse.urljoin(service.url, self.url_path.lstrip('/'))
                 break
         return url
 

--- a/threddsclient/nodes.py
+++ b/threddsclient/nodes.py
@@ -40,7 +40,7 @@ class Service(Node):
         self.base = soup.get('base')
         self.url = urlparse.urljoin(self.catalog.url, self.base)
         # To fix issues with HYRAX servers
-        if not self.url.endswith('/'):
+        if 'catalog.xml' not in self.url and not self.url.endswith('/'):
             self.url = self.url + '/'
         self.service_type = soup.get('serviceType')
         self.content_type = "application/service"


### PR DESCRIPTION
Some modifications were needed in order to traverse HYRAX servers using their implementation of THREDDS Catalogs. The PR is tested on some servers in Poland and the US and performs as intended. There are probably insufficiencies in some areas, but this PR addresses the use case I had available. 